### PR TITLE
add createAndRegisterGameObject template function

### DIFF
--- a/gameengine.cpp
+++ b/gameengine.cpp
@@ -8,13 +8,8 @@
 
 GameEngine::GameEngine(QQmlApplicationEngine *engine, QObject *parent) : QObject(parent), qmlEngine(engine)
 {
-    background = new Background(this);
-    background->registerAsQmlGameObject(engine);
-    gameObjects.append(background);
-
-    wisp = new Wisp(this);
-    wisp->registerAsQmlGameObject(engine);
-    gameObjects.append(wisp);
+    background = createAndRegisterGameObject<Background>();
+    wisp = createAndRegisterGameObject<Wisp>();
 
     QObject::connect(background->getQmlComponent(), SIGNAL(mouseLeftButtonClicked(double,double)),
                      this, SLOT(handleMouseLeftButtonClicked(double,double)));

--- a/gameengine.h
+++ b/gameengine.h
@@ -29,6 +29,16 @@ public slots:
 public:
     void spawnGameObject(GameObject::Type objType);
 
+    template<typename T>
+    T* createAndRegisterGameObject()
+    {
+        auto gameObject = new T(this);
+        gameObject->registerAsQmlGameObject(qmlEngine);
+        gameObjects.append(gameObject);
+
+        return gameObject;
+    }
+
 private:
     QVector<GameObject*> gameObjects;
     QQmlApplicationEngine *qmlEngine;


### PR DESCRIPTION
In order to avoid code duplication, add template function to
GameEngine class to create and register GameObjects.